### PR TITLE
Fixed --loop when running on Debian 9 / Added Disclaimers with detailed explanation! 

### DIFF
--- a/fixhdd.py
+++ b/fixhdd.py
@@ -60,8 +60,8 @@ def getBadSectors(device):
     "Parse a list of recently read bad sectors from the syslog"
     #TODO this gets ALL bad sectors from ALL devices, not only the selected device
     try:
-        out = subprocess.check_output('grep "end_request: I/O error" /var/log/syslog', shell=True)
-        for line in out.split("\n"):
+        out = str(subprocess.check_output('egrep "end_request: I/O error|print_req_error: I/O error" /var/log/syslog', shell=True))
+        for line in out.replace('\\n','\n').replace("'",'').split("\n"):
             line = line.strip()
             if not line: continue
             sector = int(line.rpartition(" ")[2])
@@ -89,7 +89,7 @@ def resetSectorHDParm(device, sector):
     """Write to a sector using hdparm only if reading it yields a HDD error"""
     #Will throw exception on non-zero exit code
     if isSectorBad(device, sector):
-        print(("Sector %d is damaged, rewriting..." % sector))
+        print(("Sector %d (%s) is damaged, rewriting..." % (sector, device)))
         #Maaan, this is VERY DANGEROUS!
         #Really, no kidding. Might even make things worse.
         #It could work, but it probably doesn't. Ever.
@@ -99,7 +99,7 @@ def resetSectorHDParm(device, sector):
         if "succeeded" not in out:
             print (red(out.decode("utf-8").replace("\n")))
     else:
-        print(("Sector %d is OK, ignoring" % sector))
+        print(("Sector %d (%s) is OK, ignoring" % (sector,device)))
   
 def fixBadSectors(device, badSectors):
     "One-shot fixing of bad sectors"

--- a/fixhdd.py
+++ b/fixhdd.py
@@ -55,6 +55,75 @@ __maintainer__ = "Uli Köhler"
 __email__ = "ukoehler@techoverflow.net"
 __status__ = "Development"
 
+
+DISCLAIMER = '''
+===========================[ WARNING ]===========================
+
+	DON'T RUN THIS SCRIPT IF YOU ARE AFFRAID OF
+			LOOSING DATA!
+
+	This script WILL erase data found on bad sectors on the
+disk. Even if the sector can still be partially read, it WILL
+BE ERASED and the partial data in said sector WILL BE LOST!
+
+	The aim of this script is to recover a DISK to a usable
+state, NOT TO RECOVER DATA!!
+
+        Sometimes, is still possible to retrieve the data in a
+bad sector, which this script WON'T attempt to do!!
+
+	This script will overwrite any reported bad sectors with
+ZERO bytes (0), forcing the hard driver controller to remap the
+sector to a spare pool of sectors reserved by the manufacture for
+this purpose. After a susccesfull remap, the sector will work as
+if nothing happened, and in most cases, the disk just keep working
+normally again, without weird slow dows. I had disks that worked
+for years after "fixing" bad sectors this way. (They are still
+working to this date - Feb/2019)
+
+	BE CAREFULL!! This method of fixing bad sectors can (and 
+probably will) render a filesystem in the disk unnaccessible 
+denpending on the filesystem used. XFS, Ext4 and ZFS are remarkable
+filesystems, and I was able to fix these filesystem after running 
+this script, most of the times, by running a checkdisk utility
+xfs_repair, fsck, scrub, etc), with minimal to none lost of files.
+For the times I couldn't fix, I didn't had important data on the
+disks, so I just reformated then and kept using.
+
+	For disks in RAID5/6 or ZFS ZRAID1/2 it's fairly safe to 
+use this script, since the RAID/ZRAID system will re-create the 
+lost data in said sector. In this case, make sure to run a disk 
+scrub after running this script on a disk and before trying to 
+run on another one.
+
+        THE AUTHOR/CONTRIBUTOR(S) OF THIS SCRIPT HAVE NO
+          RESPONSABILITY ABOUT ANY LOSS OF DATA CAUSED
+           BY THIS SCRIPT! USE IT AT YOUR OWN RISK!
+             BY ANSWERING "Yes" BELLOW, YOU AGREE
+                    WITH THIS DISCLAIMER!!
+
+===========================[ WARNING ]===========================\n
+'''
+
+DISCLAIMER2 = '''
+=====================[ EVEN MORE WARNING!! ]======================\n
+	USING '--loop all' IS VERY DANGEROUS IN ANY CASE,
+	       INCLUDING RAID AND ZRAID!!!!!!!!
+
+	'--loop all' WILL SCAN AND FIX ALL DISKS!! THIS MEANS
+	IT  CAN ERASE DATA ON MULTIPLE DISKS ON A RAID/ZRAID
+	   AT THE SAME TIME, MAKING IT IMPOSSIBLE FOR THE
+	    RAID/ZRAID REPAIR MECHANISMS TO RECONSTRUCT
+	                     LOST DATA!!!
+
+	ONLY USE '--loop all' IF YOU KNOWN WHAT YOU DOING AND
+	          ARE NOT AFFRAID TO LOOSE DATA!!
+
+=================[ SERIOUSLY... BE CAREFULL MAN!! ]=================\n
+
+Are you REALLY sure you want to run with '--loop all'? (Yes I am sure!/No) '''
+
+
 #Get list of recent bad sectors via dmesg
 def getBadSectors(device):
     "Parse a list of recently read bad sectors from the syslog"
@@ -94,6 +163,9 @@ def resetSectorHDParm(device, sector):
         #Really, no kidding. Might even make things worse.
         #It could work, but it probably doesn't. Ever.
         #Don't use if your data is worth a single dime to you.
+	#ps from hradec: If your disk is in a ZFS ZRAID, don't worry... running a scrub after fixing the bad sector
+        #                will re-create any lost data on the disk. Just don't do it in more than one disk at a time, 
+        #                and allways run scrub before attempting another disk!
         out = subprocess.check_output('hdparm --write-sector  %d --yes-i-know-what-i-am-doing %s' % (sector, device), shell=True)
         out = out.decode("utf-8")
         if "succeeded" not in out:
@@ -106,7 +178,7 @@ def fixBadSectors(device, badSectors):
     print(("Checking/Fixing %d sectors" % len(badSectors)))
     [resetSectorHDParm(device, sector) for sector in badSectors]
       
-def checkDmesgBadSectors(device, knownGoodSectors):
+def checkDmesgBadSectors(device, knownGoodSectors, feedback=True):
     #Grab sector list from dmesg
     devices=device
     if type(device) != type([]):
@@ -116,19 +188,21 @@ def checkDmesgBadSectors(device, knownGoodSectors):
        dmesgBadSectors = set(getBadSectors(device))
        dmesgBadSectors.difference_update(knownGoodSectors)
        if len(dmesgBadSectors) == 0:
-           print ("No new sector errors found in syslog for device %s:-)" % device)
-           #Update set of sectors which are known to be good
+           if feedback == True:
+               print ("No new sector errors found in syslog for device %s:-)" % device)
        else:
+           #Update set of sectors which are known to be good
            fixBadSectors(device, dmesgBadSectors)
            knownGoodSectors.update(dmesgBadSectors)
 
-def loopCheckForBadSectors(device):
+def loopCheckForBadSectors(device, feedback=True):
     knownGoodSectors = set()
     while True:
-        print("Waiting 5 seconds (hit Ctrl+C to interrupt)...")
+        if feedback == True:
+            print("Waiting 5 seconds (hit Ctrl+C to interrupt)...")
         time.sleep(5)
         #Try again after timeout
-        checkDmesgBadSectors(device, knownGoodSectors)
+        checkDmesgBadSectors(device, knownGoodSectors, feedback)
 
 def isBlockDevice(filename):
     "Return if the given filename represents a valid block device"
@@ -154,12 +228,15 @@ if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument("-s", "--sector", nargs="*", default=[], type=int, help="A list of sectors to scan (beyond those listed in ")
-    parser.add_argument("--loop", action="store_true", help="Loop and scan for bad sectors every few seconds")
+    parser.add_argument("--loop", action="store_true", help="Loop and scan for bad sectors every few seconds. By using 'all' as device, it will scan all disks in the system. (VERY DANGEROUS!!)")
     parser.add_argument("-a", "--active-scan", action="store_true", help="Actively scan all blocks for errors. Use --offset to start at a specific block.")
     parser.add_argument("-o", "--offset", default=0, type=int, help="For active scan, the block to start at")
     parser.add_argument("-n", default=1000, type=int, help="For active scan, the number of blocks to scan")
     parser.add_argument("device", default="/dev/sda", help="The device to use")
     args = parser.parse_args()
+
+    if input(DISCLAIMER+'Are you sure you want to use this script? (Yes/No) ') != 'Yes':
+        sys.exit(0)
 
     if args.device != "all":
      #Check if the given device is a block device after all
@@ -178,9 +255,15 @@ if __name__ == "__main__":
     # If enabled, loop-check
     if args.loop:
         if args.device == "all":
-           out = subprocess.check_output("/usr/bin/lsscsi  | awk '{print $(NF)}' | grep -v '\-'", shell=True)
-           out = out.decode("utf-8").split()
-           loopCheckForBadSectors(out)
+
+           if input(DISCLAIMER2) == 'Yes I am sure!':
+               print( "OK... Brave soul! good luck!! running..." )
+               out = subprocess.check_output("/usr/bin/lsscsi  | awk '{print $(NF)}' | grep -v '\-'", shell=True)
+               out = out.decode("utf-8").split()
+               # when running as "all", don't spit out idle messages.
+               loopCheckForBadSectors(out, feedback=False)
+           else:
+               print( "Cancelling execution... fiu... :)" )
         else:
            loopCheckForBadSectors(args.device)
 


### PR DESCRIPTION
I added a big disclaimer to try and explain what this script does, and what to expect out of it.
I also added a second disclaimer just for `--loop all` option, since it can potentially destroy data on RAID/ZRAID systems.